### PR TITLE
Add support for browsing assets packs from the Bazaar

### DIFF
--- a/modules/moulinette-file-util.js
+++ b/modules/moulinette-file-util.js
@@ -176,7 +176,7 @@ export class MoulinetteFileUtil {
         console.log(`MoulinetteFileUtil | Cannot download tiles/asset list`, e)
         return;
       });
-      if(response.status != 200) return;
+      if(response.status != 200) continue;
       let data = {}
       try {
         data = await response.json();

--- a/modules/moulinette-file-util.js
+++ b/modules/moulinette-file-util.js
@@ -155,7 +155,11 @@ export class MoulinetteFileUtil {
   static async scanAssetsInPackFolder(source, packPath, extensions, debug = false) {
     const files = await MoulinetteFileUtil.scanFolder(source, packPath, extensions, debug)
     if(debug) console.log(`Moulinette FileUtil | Pack: ${files.length} assets found.`)
-    return files.map( (path) => { return decodeURI(path).split(decodeURI(packPath))[1].substr(1) } ) // remove front /
+    packPath = decodeURI(packPath)
+    return files.map( (path) => {
+        if (path.match(/^https?:\/\//)) return path;
+        return decodeURI(path).slice(packPath.length + 1); // remove front /
+    } )
   }
   
   /**

--- a/moulinette-core.js
+++ b/moulinette-core.js
@@ -83,6 +83,14 @@ Hooks.once("ready", async function () {
     icon: "modules/moulinette-core/img/moulinette.png",
     class: (await import("./modules/moulinette-forge.js")).MoulinetteForge
   })
+  // Add asset packs from the Forge's Bazaar if running on the Forge
+  if (typeof ForgeVTT != "undefined" && ForgeVTT.usingTheForge) {
+    const result = await FilePicker.browse("forge-bazaar", "assets");
+    for (const dir of result.dirs) {
+        game.moulinette.sources.push({type: "tiles", "publisher": "Bazaar", pack: dir.slice("assets/".length), source: "forge-bazaar", path: dir});
+        game.moulinette.sources.push({type: "sounds", "publisher": "Bazaar", pack: dir.slice("assets/".length), source: "forge-bazaar", path: dir});
+    }
+  }
 });
 
 /**


### PR DESCRIPTION
Hi Sven,

I loved seeing what Moulinette does as I wanted to do something similar myself for the Bazaar content. I've done a few small tweaks to allow it to work correctly with the asset packs available on the Bazaar.
Hopefully you can merge this in. Thanks!