### PR TITLE
Fix indexing when game is not hosted on The Forge

### DIFF
--- a/modules/moulinette-file-util.js
+++ b/modules/moulinette-file-util.js
@@ -343,7 +343,7 @@ export class MoulinetteFileUtil {
     files = files.filter(f => f.indexOf("_thumb") < 0) // remove thumbnails
     if(debug) console.log(`Moulinette FileUtil | Pack: ${files.length} assets found.`)
     // special case for ForgeVTT => keep entire path
-    if(ForgeVTT.usingTheForge && source != "public") {
+    if(typeof ForgeVTT !== "undefined" && ForgeVTT.usingTheForge && source != "public") {
       return files.map( (path) => { return decodeURIComponent(path) } )
     } else {
       return files.map( (path) => { return decodeURIComponent(path).split(decodeURIComponent(packPath))[1].substr(1) } ) // remove front /


### PR DESCRIPTION
Moulinette-Core 10.2.2 breaks indexing when not hosted on The Forge. It throws a "ReferenceError: ForgeVTT is not defined" in moulinette-file-utils.js:346.

This PR fixes it by adding a check that ForgeVTT is defined before accessing the object, as is done in other places.